### PR TITLE
Adding support for CJAU-01/04 Shutter Actuator

### DIFF
--- a/pkg/xc/device.go
+++ b/pkg/xc/device.go
@@ -35,7 +35,8 @@ func (d Device) IsDimmingActuator() bool {
 
 func (d Device) IsShutter() bool {
 	return d.deviceType == DT_CJAU_0101 ||
-		d.deviceType == DT_CJAU_0102
+		d.deviceType == DT_CJAU_0102 ||
+		d.deviceType == DT_CJAU_0104
 }
 
 func (d Device) IsBatteryOperated() bool {

--- a/pkg/xc/device_types.go
+++ b/pkg/xc/device_types.go
@@ -46,6 +46,7 @@ const (
 	DT_CDAx_01NG   DeviceType = 77
 	DT_CRCA_00xx   DeviceType = 78
 	DT_CHAX_010x   DeviceType = 81
+	DT_CJAU_0104   DeviceType = 86
 )
 
 // We don't pay attention to channel modes yet, this is a simplification.
@@ -118,5 +119,6 @@ var names = map[DeviceType]deviceInfo{
 	DT_CDAx_01NG:   {"Dimming Actuator New Generation (CDAx-01/xx)", []channelType{STATUS_PERCENT, SWITCH, SWITCH, ENERGY, POWER, ONOFF}},
 	DT_CRCA_00xx:   {"Room Controller Touch (CRCA-00/xx)", []channelType{TEMPERATURE_WHEEL_SWITCH, HUMIDITY_SWITCH, UNKNOWN, UNKNOWN, PUSHBUTTON, PUSHBUTTON, TEMPERATURE_SWITCH, SWITCH}},
 	DT_CHAX_010x:   {"Heating actuator (CHAx-01/xx)", []channelType{DIMPLEX, UNKNOWN, ENERGY, ONOFF}},
+	DT_CJAU_0104:   {"Shutter Actuator (CJAU-01/04)", []channelType{STATUS_SHUTTER}},
 	//69: "Rosetta Router",
 }


### PR DESCRIPTION
I added the CJAU-01/04 to my system, performed the normal actions in MRF, and this is from the log after starting xcomfortd:
2023/10/04 09:37:48 Unknown device type 86

This PR will add support for the mentioned Shutter Actuator.