### PR TITLE
Adding extended status support for shutters

### DIFF
--- a/ha_discovery.go
+++ b/ha_discovery.go
@@ -173,13 +173,16 @@ func createDpDiscoveryMessages(discoveryPrefix, clientId string,
 
 	case xc.STATUS_SHUTTER:
 		config["command_topic"] = fmt.Sprintf("%s/%d/set/shutter", clientId, dataPoint)
+		config["position_topic"] = fmt.Sprintf("%s/%d/get/position", clientId, dataPoint)
 		config["payload_open"] = "open"
 		config["payload_close"] = "close"
 		config["payload_stop"] = "stop"
 		config["state_topic"] = fmt.Sprintf("%s/%d/get/shutter", clientId, dataPoint)
-		config["state_opening"] = xc.ShutterOpening
-		config["state_closing"] = xc.ShutterClosing
-		config["state_stopped"] = xc.ShutterStopped
+		config["state_opening"] = xc.ShutterStateOpening
+		config["state_closing"] = xc.ShutterStateClosing
+		config["state_stopped"] = xc.ShutterStateStopped
+		config["state_open"] = xc.ShutterStateOpen
+		config["state_closed"] = xc.ShutterStateClosed
 
 		addMsg, err := json.Marshal(config)
 		if err != nil {

--- a/pkg/xc/device.go
+++ b/pkg/xc/device.go
@@ -134,7 +134,10 @@ func (d *Device) extendedStatus(h Handler, data []byte) error {
 		d.extendedStatusSwitch(h, data[2:])
 	case d.IsHeatingActuator():
 		d.extendedStatusHeatingActuator(h, data[2:])
+	case d.IsShutter():
+		d.extendedStatusShutter(h, data[2:])
 	default:
+		log.Printf("Device type: %s", d.deviceType)
 		log.Printf("extended status message from unhandled device %d", data[0])
 		return errMsgNotHandled
 	}

--- a/pkg/xc/shutter.go
+++ b/pkg/xc/shutter.go
@@ -18,9 +18,13 @@ const (
 type ShutterStatus string
 
 const (
-	ShutterStopped ShutterStatus = "stopped"
-	ShutterOpening ShutterStatus = "opening"
-	ShutterClosing ShutterStatus = "closing"
+	ShutterStateStopped ShutterStatus = "stopped"
+	ShutterStateOpening ShutterStatus = "opening"
+	ShutterStateClosing ShutterStatus = "closing"
+	ShutterStateClosed  ShutterStatus = "closed"
+	ShutterStateOpen    ShutterStatus = "open"
+
+	ShutterStateUnknown ShutterStatus = "unknown"
 )
 
 func (d *Datapoint) Shutter(ctx context.Context, cmd ShutterCommand) ([]byte, error) {
@@ -31,18 +35,51 @@ func (d *Datapoint) Shutter(ctx context.Context, cmd ShutterCommand) ([]byte, er
 }
 
 func (d *Datapoint) shutterStatus(h Handler, status byte) (string, error) {
+	log.Printf("Shutter status: %s: ", status)
 	switch status {
 	case RX_IS_STOP:
-		h.StatusShutter(d, ShutterStopped)
+		h.StatusShutter(d, ShutterStateStopped)
 		return "status shutter stopped", nil
 	case RX_IS_OPEN:
-		h.StatusShutter(d, ShutterOpening)
+		h.StatusShutter(d, ShutterStateOpening)
 		return "status shutter opening", nil
 	case RX_IS_CLOSE:
-		h.StatusShutter(d, ShutterClosing)
+		h.StatusShutter(d, ShutterStateClosing)
 		return "status shutter closing", nil
 	default:
 		log.Printf("unknown shutter status %d\n", status)
 		return "unknown", errMsgNotHandled
 	}
 }
+
+func (d *Device) extendedStatusShutter(h Handler, data []byte) {
+	log.Printf("====Subtype: %d\n", d.subtype)
+
+	status := data[1]
+
+	shutterState := ShutterStateOpen
+
+	switch status {
+	case CJAU_OPEN:
+	case CJAU_CLOSED:
+		shutterState = ShutterStateClosed
+	default:
+		shutterState = ShutterStateStopped
+	}
+
+	for _, dp := range d.datapoints {
+		if dp.channel == 0 {
+			// Status channel is always 0
+			h.StatusShutter(dp, shutterState)
+			break
+		}
+	}
+
+	log.Printf("Device %d, type %s sent extended status message: {shutterState: %s, closedPercentage: %d})\n", d.serialNumber, names[d.deviceType].name, shutterState, status)
+}
+
+const (
+	CJAU_OPEN    = 0x0
+	CJAU_CLOSED  = 0x64
+	CJAU_STOPPED = 0xFF
+)


### PR DESCRIPTION
This change has been running successfylly together with CJAU-01/04. I have not been able to test it on CJAU-01/02.

- Added 2 new states: state_open and state_closed
- Renamed ShutterStatus constants because of a naming conflict with the shutter command ShutterOpen.
- Adding extended status support for shutters.